### PR TITLE
Stick to setup-buildx-action

### DIFF
--- a/.github/workflows/build-crossplatform.yml
+++ b/.github/workflows/build-crossplatform.yml
@@ -63,7 +63,7 @@ jobs:
           platforms: ${{ matrix.platform }}
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3.1.0
       -
         name: Login to DockerHub
         uses: docker/login-action@v3


### PR DESCRIPTION
Stick to older setup-buildx-action after ARM build breaks with

error: failed to list workers: Unavailable: connection error: desc = "transport: Error while dialing: dial unix /run/buildkit/buildkitd.sock: connect: no such file or directory"