### PR TITLE
Update dependency to openssl4j-objects.version

### DIFF
--- a/openssl4j/pom.xml
+++ b/openssl4j/pom.xml
@@ -10,7 +10,7 @@
   <name>OpenSSL4J JNI</name>
   <description>Java binding to OpenSSL library functions</description>
   <properties>
-    <openssl4j-objects.version>2023-10-21-08-46-22</openssl4j-objects.version>
+    <openssl4j-objects.version>2024-08-07-13-59-34</openssl4j-objects.version>
   </properties>
   <build>
     <resources>


### PR DESCRIPTION
The old objects version was gone, using new one here